### PR TITLE
Fix incorrect clone URL and folder name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ Ensure you have the following installed:
 2. Run the following command to clone the repository:
 
     ```bash
-    git clone https://github.com/zendalona/WorldMapExplorer.git
+    git clone https://github.com/zendalona/world-map-explorer-v2.git
     ```
 
 3. Navigate into the project directory:
 
     ```bash
-    cd WorldMapExplorer
+    cd world-map-explorer-v2
     ```
 
 ---


### PR DESCRIPTION
The repository name was changed, but the clone instructions were not updated in the README. This PR fixes the clone URL and folder name to reflect the updated repository. 😊